### PR TITLE
adding large file testing options to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
 
 # Handle user build options.
 OPTION(ENABLE_LARGE_FILE_TESTS "Enable large file tests." OFF)
-if (not TEST_LARGE)
+if (NOT TEST_LARGE)
   set(TEST_LARGE "data")
 endif ()
 cmake_print_variables(ENABLE_LARGE_FILE_TESTS TEST_LARGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ include(CMakePrintHelpers)
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
   CACHE INTERNAL "Location of our custom CMake modules.")
 
+# Handle user build options.
+OPTION(ENABLE_LARGE_FILE_TESTS "Enable large file tests." OFF)
+if (not TEST_LARGE)
+  set(TEST_LARGE "data")
+endif ()
+cmake_print_variables(ENABLE_LARGE_FILE_TESTS TEST_LARGE)
+
 # Find netCDF.
 include(FindNetCDF)
 find_package(NetCDF REQUIRED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,9 +30,33 @@ target_link_libraries(t2 ${CMD_OUTPUT})
 
 add_test(NAME t2 COMMAND t2)
 
+# Make sure the necessary data file is present in the build directory.
 configure_file(data/MOD05_L2.A2005349.2125.061.2017294065400.hdf data/MOD05_L2.A2005349.2125.061.2017294065400.hdf COPYONLY)
 
+# Configure the file that runs large file tests.
+configure_file(run_large_file_tests.sh.in run_large_file_tests.sh @ONLY)
+
+# Find bash.
+find_program(HAVE_BASH bash)
+
+# Macro to add a shell test.
+MACRO(add_sh_test F)
+  IF(HAVE_BASH)
+    ADD_TEST(${F} bash "-c" "export srcdir=${CMAKE_CURRENT_SOURCE_DIR};export TOPSRCDIR=${CMAKE_SOURCE_DIR};${CMAKE_CURRENT_BINARY_DIR}/${F}.sh")
+  ENDIF()
+ENDMACRO()
+
+# Add the shell test that always runs.
+add_sh_test(run_tests)
+
+# This shell test only runs if the ENABLE_LARGE_FILE_TESTS option was
+# set.
+if (ENABLE_LARGE_FILE_TESTS)
+  add_sh_test(run_large_file_tests)
+endif()
+
 #FILE(GLOB COPY_FILES ${CMAKE_BINARY_DIR}/test/*.hdf ${CMAKE_CURRENT_SOURCE_DIR}/test/*.sh)
-#FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
+FILE(GLOB COPY_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.sh)
+FILE(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/ FILE_PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE)
 
 


### PR DESCRIPTION
Fixes #19 

In this PR I add the large file handling to the CMake build. When this is done, both builds will be able to optionally handle the large file tests.