### PR TITLE
started using caches in GitHub workflow for autotools build

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       CPPFLAGS: "-I/usr/include -I/usr/local/include -I~/hdf4"
       LDFLAGS: "-L~/hdf4"
+      PWD_DIR: `pwd`
         
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +31,7 @@ jobs:
         wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
         tar zxf hdf-4.2.13.tar.gz
         cd hdf-4.2.13
-        ./configure --disable-netcdf --prefix=~/hdf4
+        ./configure --disable-netcdf --prefix=${PWD_DIR}/hdf4
         make all 
         sudo make install clean
         cd ..

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CPPFLAGS: "-I/usr/include -I/usr/local/include -I~/hdf4"
-      LDFLAGS: "-L~/hdf4"
       PWD_DIR: /home/runner
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I${PWD_DIR}/hdf4"
+      LDFLAGS: "-L${PWD_DIR}/hdf4"
         
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -24,6 +24,8 @@ jobs:
       run: |
         pushd ~
         pwd
+        echo $CPPFLAGS
+        echo $LDFLAGS
         popd
         wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
         tar zxf hdf-4.2.13.tar.gz

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CPPFLAGS: "-I/usr/include -I/usr/local/include"
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I`pwd`/hdf4"
+      LDFLAGS: "-L`pwd`/hdf4"
         
     steps:
     - uses: actions/checkout@v2
@@ -27,7 +28,7 @@ jobs:
         wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
         tar zxf hdf-4.2.13.tar.gz
         cd hdf-4.2.13
-        ./configure --disable-netcdf --prefix=/usr/local
+        ./configure --disable-netcdf --prefix=`pwd`/hdf4
         make all 
         sudo make install clean
         cd ..

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -1,4 +1,4 @@
-name: Autotools build
+name: Autotools ubuntu-latest
 
 on:
   push:

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CPPFLAGS: "-I/usr/include -I/usr/local/include -I~/hdf4"
       LDFLAGS: "-L~/hdf4"
-      PWD_DIR: `pwd`
+      PWD_DIR: /home/runner
         
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -39,8 +39,8 @@ jobs:
     - name: HDF-EOS2 setup
       run: |
         set -x
-        export CPPFLAGS="-I/home/runner/hdf4"
-        export LDFLAGS="-L/home/runner/hdf4"
+        export CPPFLAGS="-I/home/runner/hdf4/include"
+        export LDFLAGS="-L/home/runner/hdf4/libs"
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -21,8 +21,7 @@ jobs:
     - name: Installs
       run: |
         sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
-        
-   - name: cache-hdf4
+    - name: cache-hdf4
       id: cache-hdf4
       uses: actions/cache@v2
       with:

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/hdf4
-        key: pfunit-${{ runner.os }}-4.2.13
+        key: hdf4-${{ runner.os }}-4.2.13
 
     - name: build-hdf4
       if: steps.cache-hdf4.outputs.cache-hit != 'true'
@@ -45,7 +45,15 @@ jobs:
         make all 
         sudo make install clean
         cd ..
-    - name: HDF-EOS2 setup
+    - name: cache-hdfeos2
+      id: cache-hdfeos2
+      uses: actions/cache@v2
+      with:
+        path: ~/hdfeos2
+        key: hdfeos2-${{ runner.os }}-20v1.00
+
+    - name: build-hdfeos2
+      if: steps.cache-hdfeos2.outputs.cache-hit != 'true'
       run: |
         set -x
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
@@ -53,7 +61,7 @@ jobs:
         cd hdfeos
         ./configure  --enable-install-include --prefix=${PWD_DIR}/hdfeos2
         make
-        sudo make install
+        sudo make install clean
         cd ..
     - name: STARE setup
       run: |

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -13,8 +13,8 @@ jobs:
 
     env:
       PWD_DIR: /home/runner
-      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/hdf4/include"
-      LDFLAGS: "-L/home/runner/hdf4/lib"
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/hdf4/include -I/home/runner/stare/include -I/home/runner/hdfeos2/include"
+      LDFLAGS: "-L/home/runner/hdf4/lib -L/home/runner/stare/lib -L/home/runner/hdfeos2/lib"
         
     steps:
     - uses: actions/checkout@v2
@@ -25,6 +25,7 @@ jobs:
       run: |
         set -x
         pushd ~
+        echo $HOME
         pwd
         echo $CPPFLAGS
         echo $LDFLAGS
@@ -42,7 +43,7 @@ jobs:
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos
-        ./configure  --enable-install-include --prefix=/usr/local
+        ./configure  --enable-install-include --prefix=${PWD_DIR}/hdfeos2
         make
         sudo make install
         cd ..
@@ -54,7 +55,7 @@ jobs:
         cd STARE-0.15.6-beta/
         mkdir build
         cd build
-        cmake ..
+        cmake -DCMAKE_INSTALL_PREFIX=~/stare ..
         make all
         sudo make install
         cd ../..

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         set -x
         export CPPFLAGS="-I/home/runner/hdf4/include"
-        export LDFLAGS="-L/home/runner/hdf4/libs"
+        export LDFLAGS="-L/home/runner/hdf4/lib"
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -39,6 +39,8 @@ jobs:
     - name: HDF-EOS2 setup
       run: |
         set -x
+        export CPPFLAGS="-I/home/runner/hdf4"
+        export LDFLAGS="-L/home/runner/hdf4"
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -21,6 +21,9 @@ jobs:
         sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
     - name: HDF4 setup
       run: |
+        pushd ~
+        pwd
+        popd
         wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
         tar zxf hdf-4.2.13.tar.gz
         cd hdf-4.2.13

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -21,7 +21,16 @@ jobs:
     - name: Installs
       run: |
         sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
-    - name: HDF4 setup
+        
+   - name: cache-hdf4
+      id: cache-hdf4
+      uses: actions/cache@v2
+      with:
+        path: ~/hdf4
+        key: pfunit-${{ runner.os }}-4.2.13
+
+    - name: build-hdf4
+      if: steps.cache-hdf4.outputs.cache-hit != 'true'
       run: |
         set -x
         pushd ~

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -30,7 +30,7 @@ jobs:
         wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
         tar zxf hdf-4.2.13.tar.gz
         cd hdf-4.2.13
-        ./configure --disable-netcdf --prefix=`pwd`/hdf4
+        ./configure --disable-netcdf --prefix=~/hdf4
         make all 
         sudo make install clean
         cd ..

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -13,8 +13,8 @@ jobs:
 
     env:
       PWD_DIR: /home/runner
-      CPPFLAGS: "-I/usr/include -I/usr/local/include -I${PWD_DIR}/hdf4"
-      LDFLAGS: "-L${PWD_DIR}/hdf4"
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/hdf4"
+      LDFLAGS: "-L/home/runner/hdf4"
         
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
         echo $CPPFLAGS
         echo $LDFLAGS
         popd
-        wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz
+        wget https://support.hdfgroup.org/ftp/HDF/HDF_Current/src/hdf-4.2.13.tar.gz &> /dev/null
         tar zxf hdf-4.2.13.tar.gz
         cd hdf-4.2.13
         ./configure --disable-netcdf --prefix=${PWD_DIR}/hdf4
@@ -38,7 +38,8 @@ jobs:
         cd ..
     - name: HDF-EOS2 setup
       run: |
-        wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z
+        set -x
+        wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos
         ./configure  --enable-install-include --prefix=/usr/local
@@ -47,7 +48,8 @@ jobs:
         cd ..
     - name: STARE setup
       run: |
-        wget https://github.com/SpatioTemporal/STARE/archive/0.15.6-beta.tar.gz
+        set -x
+        wget https://github.com/SpatioTemporal/STARE/archive/0.15.6-beta.tar.gz  &> /dev/null
         tar zxf 0.15.6-beta.tar.gz
         cd STARE-0.15.6-beta/
         mkdir build

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -23,6 +23,7 @@ jobs:
         sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
     - name: HDF4 setup
       run: |
+        set -x
         pushd ~
         pwd
         echo $CPPFLAGS

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -63,7 +63,15 @@ jobs:
         make
         sudo make install clean
         cd ..
-    - name: STARE setup
+    - name: cache-stare
+      id: cache-stare
+      uses: actions/cache@v2
+      with:
+        path: ~/stare
+        key: stare-${{ runner.os }}-0.15.6
+
+    - name: build-stare
+      if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
         set -x
         wget https://github.com/SpatioTemporal/STARE/archive/0.15.6-beta.tar.gz  &> /dev/null

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -13,8 +13,8 @@ jobs:
 
     env:
       PWD_DIR: /home/runner
-      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/hdf4"
-      LDFLAGS: "-L/home/runner/hdf4"
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/hdf4/include"
+      LDFLAGS: "-L/home/runner/hdf4/lib"
         
     steps:
     - uses: actions/checkout@v2
@@ -39,8 +39,6 @@ jobs:
     - name: HDF-EOS2 setup
       run: |
         set -x
-        export CPPFLAGS="-I/home/runner/hdf4/include"
-        export LDFLAGS="-L/home/runner/hdf4/lib"
         wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
         tar zxf HDF-EOS2.20v1.00.tar.Z
         cd hdfeos

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CPPFLAGS: "-I/usr/include -I/usr/local/include -I`pwd`/hdf4"
-      LDFLAGS: "-L`pwd`/hdf4"
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I~/hdf4"
+      LDFLAGS: "-L~/hdf4"
         
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
In our CI workflows, we must build the HDF4, HDFEOS2, and STARE libraries before running each set of tests.

GitHub has a cache feature, which allows us to cache the builds of these libraries, so they don't have to be rebuilt each time. The result is our testing is much faster and therefore provides better feedback to programmers.

Part of #17