### PR TITLE
better detection of netCDF, check HDF4 for netcdf build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ HDFEOS2 | 1.00                  | https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos
 HDF5    | 1.8.x, 1.10.x, 1.12.x | https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.gz
 netcdf-c| 4.x                   | https://github.com/Unidata/netcdf-c/releases
 
+### Build Notes
+
+When building HDF4 and HDFEOS2, there are some build issues. As
+demonstrated in the GitHub workflow
+builds(ex. https://github.com/SpatioTemporal/STAREmaster/blob/master/.github/workflows/autotools.yml),
+set the CFLAGS to -fPIC.
+
+When building HDF4, the --disable-netcdf option must be used.
+
+Building HDF4 can be accomplished with these commands:
+
+<pre>
+export CFLAGS=-fPIC
+./configure --prefix=/usr/local/hdf-4.2.15_fPIC --disable-netcdf
+make all
+make check
+sudo make install
+</pre>
+
+When building hdfeos, the --enable-install-include option must be used
+with configure. Building hdfeos can be accomplished with these commands:
+
+<pre>
+export CPPFLAGS=-I/usr/local/hdf-4.2.15_fPIC/include LDFLAGS=-L/usr/local/hdf-4.2.15_fPIC/lib
+export CFLAGS=-fPIC
+./configure --prefix=/usr/local/hdfeos_fPIC --enable-install-include
+make all
+make check
+sudo make install
+</pre>
+
 ### Building with Autotools
 
 When building with autotools locations of all required header files

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ files. For full documentation, see
 https://spatiotemporal.github.io/STAREmaster/
 
 For more info about STARE, see [the STARE GitHub
-site](https://github.com/SpatioTemporal/STARE)
+site](https://github.com/SpatioTemporal/STARE) and [STARE - TOWARD
+UNPRECEDENTED GEO-DATA
+INTEROPERABILITY](https://www.researchgate.net/publication/320908197_STARE_-_TOWARD_UNPRECEDENTED_GEO-DATA_INTEROPERABILITY).
 
 ## Supported Datasets
 
@@ -102,10 +104,29 @@ createSidecarFile -d MOD09 data/MYD09.A2020058.1515.006.2020060020205.hdf
 
 ## References
 
-HDF-EOS Library User's Guide Volume 1: Overview and Examples, retrieved Sep 7, 2020 from http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS_UG.pdf
+Kuo, K-S and ML Rilee, “STARE – Toward unprecedented geo-data
+interoperability,” 2017 Conference on Big Data from Space. Toulouse,
+France. 28-30 November 2017, retrieved on Sep 19,2020 from
+https://www.researchgate.net/publication/320908197_STARE_-_TOWARD_UNPRECEDENTED_GEO-DATA_INTEROPERABILITY.
 
-HDF-EOS Library User's Guide Volume 2: Function Reference Guide,  retrieved Sep 7, 2020 from http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS_REF.pdf
+Kuo, K-S, H. YuYu, and ML Rilee, "Leveraging STARE for Co-aligned Data
+Locality with netCDF and Python MPI", 2019 IEEE International
+Geoscience and Remote Sensing Symposium, June 2019, retrieved on Sep
+19, 2020 from
+https://www.researchgate.net/publication/337504144_Leveraging_STARE_for_Co-aligned_Data_Locality_with_netCDF_and_Python_MPI.
 
-HDF-EOS Interface Based on HDF5, Volume 1: Overview and Examples, retrieved Sep 7, 2020 from http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS5_UG.pdf
+HDF-EOS Library User's Guide Volume 1: Overview and Examples,
+retrieved Sep 7, 2020 from
+http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS_UG.pdf
 
-HDF-EOS Interface Based on HDF5, Volume 2: Function Reference Guide, retrieved Sep 7, 2020 from http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS5_REF.pdf
+HDF-EOS Library User's Guide Volume 2: Function Reference Guide,
+retrieved Sep 7, 2020 from
+http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS_REF.pdf
+
+HDF-EOS Interface Based on HDF5, Volume 1: Overview and Examples,
+retrieved Sep 7, 2020 from
+http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS5_UG.pdf
+
+HDF-EOS Interface Based on HDF5, Volume 2: Function Reference Guide,
+retrieved Sep 7, 2020 from
+http://newsroom.gsfc.nasa.gov/sdptoolkit/docs/2.20/HDF-EOS5_REF.pdf

--- a/configure.ac
+++ b/configure.ac
@@ -103,15 +103,10 @@ AC_LANG_POP()
 #AC_CHECK_LIB([m], [floor], [],
 #[AC_MSG_ERROR([Can't find or link to the math library.])])
 
-# Check for netCDF C library.
-USE_NETCDF=no
+# Check for netCDF C library and header. It is required.
 AC_SEARCH_LIBS([nc_create], [netcdf], [USE_NETCDF=yes],
-                            [AC_MSG_WARN([Can't find or link to the netcdf C library; will build without netCDF capability.])])
-AC_MSG_CHECKING([whether to use netCDF])			    
-AC_MSG_RESULT([$USE_NETCDF])
-if test "$USE_NETCDF" = yes; then
-   AC_DEFINE([USE_NETCDF], [1], [If true, use NetCDF.])
-fi
+                            [AC_MSG_ERROR([Cannot link to the netcdf C library, set LDFLAGS.])])
+AC_CHECK_HEADERS([netcdf.h], [], [AC_MSG_ERROR([Cannot find netcdf.h, set CPPFLAGS.])])			    
 
 # Check for HDF5 library.
 USE_HDF5=no
@@ -124,14 +119,12 @@ if test "$USE_HDF5" = yes; then
 fi
 
 # Find HDF4 and all the trimmings.
-dnl AC_CHECK_LIB([jpeg], [jpeg_CreateCompress], [],
-dnl              [AC_MSG_ERROR([Jpeg library required for --enable-hdf4 builds.])])
 AC_CHECK_HEADERS([mfhdf.h], [], [AC_MSG_ERROR([Cannot find mfhdf.h, set CPPFLAGS.])])
 AC_CHECK_HEADERS([hdf.h], [], [AC_MSG_ERROR([Cannot find hdf.h, set CPPFLAGS.])])
 AC_CHECK_LIB([z], [deflate], [], [])
 AC_CHECK_LIB([jpeg], [jpeg_set_quality], [], [])
 AC_CHECK_LIB([df], [Hclose], [], [])
-# AC_CHECK_LIB([mfhdf], [NC_arrayfill], [AC_MSG_ERROR([HDF4 library must be built with --disable-netcdf.])])
+AC_CHECK_LIB([mfhdf], [NC_arrayfill], [AC_MSG_ERROR([HDF4 library must be built with --disable-netcdf.])])
 AC_SEARCH_LIBS([SDcreate], [mfhdf], [USE_HDF4=yes], [USE_HDF4=no])
 
 AC_MSG_CHECKING([whether to use HDF4])			    
@@ -145,11 +138,6 @@ fi
 AC_SEARCH_LIBS([cos], [m], [], [AC_MSG_ERROR([math library required])])
 AC_SEARCH_LIBS([SWopen], [hdfeos], [], [AC_MSG_ERROR([hdfeos library required])])
 AC_CHECK_HEADERS([HdfEosDef.h], [], [AC_MSG_ERROR([Cannot find HdfEosDef.h, set CPPFLAGS.])], [#include "mfhdf.h"])
-
-# Either netCDF or HDF5 must be provided.
-if test "$USE_HDF5" = no -a "$USE_NETCDF" = no -a "$USE_HDF4" = no; then
-   AC_MSG_ERROR([Cannot find netCDF, HDF4, or HDF5. Set CPPFLAGS/LDFLAGS.])
-fi
 
 # We need ncdump for testing.
 AC_CHECK_PROG(NCDUMP,[ncdump],[ncdump],[no])


### PR DESCRIPTION
Part of #74 
Part of #73 
Part of #62

Some improvements to the autotools build, and some additional build notes for the README relating to HDF4 and hdfeos, which must be built with the proper options. Also added some references to the README regarding STARE.