### PR TITLE
updating CMake workflow to use STARE 0.16.2-beta

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -21,11 +21,12 @@ jobs:
     - name: Installs
       run: |
         set -x
-        sudo gem install apt-spy2
-        sudo apt-spy2 check
-        sudo apt-spy2 fix --commit
+# Uncomment the following if apt-get starts failing to work.        
+#        sudo gem install apt-spy2
+#        sudo apt-spy2 check
+#        sudo apt-spy2 fix --commit
         # after selecting a specific mirror, we need to run 'apt-get update'
-        sudo apt-get update
+#        sudo apt-get update
         sudo apt-get install -o Acquire::Retries=3 netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
     - name: cache-hdf4
       id: cache-hdf4

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -21,12 +21,6 @@ jobs:
     - name: Installs
       run: |
         set -x
-# Uncomment the following if apt-get starts failing to work.        
-#        sudo gem install apt-spy2
-#        sudo apt-spy2 check
-#        sudo apt-spy2 fix --commit
-        # after selecting a specific mirror, we need to run 'apt-get update'
-#        sudo apt-get update
         sudo apt-get install -o Acquire::Retries=3 netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
     - name: cache-hdf4
       id: cache-hdf4

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -69,15 +69,15 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/stare
-        key: stare-${{ runner.os }}-0.15.6
+        key: stare-${{ runner.os }}-0.16.2
 
     - name: build-stare
       if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
         set -x
-        wget https://github.com/SpatioTemporal/STARE/archive/0.15.6-beta.tar.gz  &> /dev/null
-        tar zxf 0.15.6-beta.tar.gz
-        cd STARE-0.15.6-beta/
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.2-beta.tar.gz  &> /dev/null
+        tar zxf 0.16.2-beta.tar.gz
+        cd STARE-0.16.2-beta/
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=~/stare ..

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,11 +21,6 @@ jobs:
     - name: Installs
       run: |
         set -x
-        sudo gem install apt-spy2
-        sudo apt-spy2 check
-        sudo apt-spy2 fix --commit
-        # after selecting a specific mirror, we need to run 'apt-get update'
-        sudo apt-get update
         sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
     - name: cache-hdf4
       id: cache-hdf4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -67,14 +67,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/stare
-        key: stare-${{ runner.os }}-0.15.6
+        key: stare-${{ runner.os }}-0.16.2
 
     - name: build-stare
       if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/SpatioTemporal/STARE/archive/0.15.6-beta.tar.gz &> /dev/null
-        tar zxf 0.15.6-beta.tar.gz
-        cd STARE-0.15.6-beta/
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.2-beta.tar.gz &> /dev/null
+        tar zxf 0.16.2-beta.tar.gz
+        cd STARE-0.16.2-beta/
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=~/stare ..


### PR DESCRIPTION
Fixes #67 
Updating STARE version in cmake workflow.

Fixes #78
Also seeing if I can now turn off some extra-slow apt-get commands I had to add to fix recent ubuntu problem.