### PR TITLE
now check STARE library version (also referenced video of talk in README)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,7 +85,7 @@ jobs:
         cd build
         nc-config --libs
         export LIBS=`nc-config --libs`
-        cmake -DCMAKE_BUILD_TYPE=Debug --trace-source=test/CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cmake -DCMAKE_BUILD_TYPE=Debug --trace-source=CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
         make VERBOSE=1
         make VERBOSE=1 test
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,6 +86,7 @@ jobs:
         nc-config --libs
         export LIBS=`nc-config --libs`
         cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Debug --trace-source=CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cat CMakeFiles/CMakeOutput.log
         make VERBOSE=1
         make VERBOSE=1 test
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Installs
       run: |
         set -x
-        sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
+        sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev build-essential
     - name: cache-hdf4
       id: cache-hdf4
       uses: actions/cache@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,7 +85,7 @@ jobs:
         cd build
         nc-config --libs
         export LIBS=`nc-config --libs`
-        cmake -DCMAKE_BUILD_TYPE=Debug --trace-source=CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Debug --trace-source=CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
         make VERBOSE=1
         make VERBOSE=1 test
 

--- a/.github/workflows/cmake_2.yml
+++ b/.github/workflows/cmake_2.yml
@@ -64,14 +64,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/stare
-        key: stare-${{ runner.os }}-0.16.2
+        key: stare-${{ runner.os }}-0.16.3
 
     - name: build-stare
       if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/SpatioTemporal/STARE/archive/0.16.2-beta.tar.gz &> /dev/null
-        tar zxf 0.16.2-beta.tar.gz
-        cd STARE-0.16.2-beta/
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.3-beta.tar.gz &> /dev/null
+        tar zxf 0.16.3-beta.tar.gz
+        cd STARE-0.16.3-beta/
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=~/stare ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,6 @@ CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
 #if STARE_VERSION_MINOR < 16
-#error
 #endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,14 +141,6 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 16
-#error
-#endif
-#if STARE_VERSION_MINOR == 16
-#if STARE_VERSION_PATCH < 3
-#error
-#endif
-#endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,11 @@ CHECK_C_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
 #if STARE_VERSION_MINOR < 16
-#error
+ no good
 #endif
 #if STARE_VERSION_MINOR == 16
 #if STARE_VERSION_PATCH < 3
-#error
+ no good
 #endif
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,10 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MAJOR < 16
+#if STARE_VERSION_MINOR < 16
+#if STARE_VERSION_PATCH < 3
  choke me
+#endif
 #endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,8 @@ CHECK_CXX_SOURCE_COMPILES("
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)
+file(READ /home/runner/work/STAREmaster/STAREmaster/build/CMakeFiles/CMakeOutput.log LOGFILE)
+cmake_print_variables(LOGFILE)
 if (NOT GOOD_STARE_VERSION)
   MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,9 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#error
+#endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 15
+#if STARE_VERSION_MINOR < 1
  choke me
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ CHECK_CXX_SOURCE_COMPILES("
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)
-file(READ /home/runner/work/STAREmaster/STAREmaster/build/CMakeFiles/CMakeOutput.log LOGFILE)
+file(READ CMakeFiles/CMakeOutput.log LOGFILE)
 cmake_print_variables(LOGFILE)
 if (NOT GOOD_STARE_VERSION)
   MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if 16 < 16
+#if STARE_VERSION_MAJOR < 16
  choke me
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,9 @@ CHECK_C_SOURCE_COMPILES("
 #endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
+if (NOT GOOD_STARE_VERSION)
+  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
+endif ()
 
 # Ensure that ncdump is available for testing.
 find_program(NCDUMP NAMES ncdump)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 16
+#if STARE_VERSION_MINOR < 0
  choke me
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,22 @@ if (NOT STARE_FOUND)
   message(fatal_error " STARE library is required.")
 endif()
 
+# Check STARE version, must be 0.16.3 or later.
+INCLUDE(CheckCSourceCompiles)
+CHECK_C_SOURCE_COMPILES("
+#include <STARE.h>
+#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#error
+#endif
+#if STARE_VERSION_MINOR == 16
+#if STARE_VERSION_PATCH < 3
+#error
+#endif
+#endif
+#endif
+int main() {return 0;}" GOOD_STARE_VERSION)
+
 # STARE requires C++11
 add_compile_options( -std=c++11 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,8 +152,6 @@ CHECK_CXX_SOURCE_COMPILES("
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)
-file(READ CMakeFiles/CMakeOutput.log LOGFILE)
-cmake_print_variables(LOGFILE)
 if (NOT GOOD_STARE_VERSION)
   MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 1
+#if 16 < 16
  choke me
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
 #if STARE_VERSION_MINOR < 16
+ choke me
 #endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,8 @@ cmake_print_variables(STARE_LIBRARIES)
 set(CMAKE_REQUIRED_LINK_OPTIONS "-L${STARE_LIBRARIES}")
 set(CMAKE_REQUIRED_LIBRARIES "STARE")
 INCLUDE(CheckCXXSourceCompiles)
+FILE(READ "/home/runner/stare/include/STARE.h" LOGFILE)
+cmake_print_variables(LOGFILE)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,28 @@ endif()
 # STARE requires C++11
 add_compile_options( -std=c++11 )
 
+# Check STARE version, must be 0.16.3 or later.
+set(CMAKE_REQUIRED_INCLUDES "${STARE_INCLUDE_DIR}")
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+cmake_print_variables(STARE_LIBRARIES)
+set(CMAKE_REQUIRED_LINK_OPTIONS "-L${STARE_LIBRARIES}")
+set(CMAKE_REQUIRED_LIBRARIES "STARE")
+INCLUDE(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+#include <STARE.h>
+#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#if STARE_VERSION_PATCH < 3
+ choke me
+#endif
+#endif
+#endif
+int main() {return 0;}" GOOD_STARE_VERSION)
+cmake_print_variables(GOOD_STARE_VERSION)
+if (NOT GOOD_STARE_VERSION)
+  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
+endif ()
+
 # Ensure that ncdump is available for testing.
 find_program(NCDUMP NAMES ncdump)
 cmake_print_variables(NCDUMP)
@@ -130,28 +152,6 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}"
   "${HDF4_INCLUDE_DIR}"
   "${HDFEOS2_INCLUDE_DIR}"
   "${STARE_INCLUDE_DIR}")
-
-# Check STARE version, must be 0.16.3 or later.
-set(CMAKE_REQUIRED_INCLUDES "${STARE_INCLUDE_DIR}")
-set(CMAKE_REQUIRED_FLAGS "-std=c++11")
-cmake_print_variables(STARE_LIBRARIES)
-set(CMAKE_REQUIRED_LINK_OPTIONS "-L${STARE_LIBRARIES}")
-set(CMAKE_REQUIRED_LIBRARIES "STARE")
-INCLUDE(CheckCXXSourceCompiles)
-CHECK_CXX_SOURCE_COMPILES("
-#include <STARE.h>
-#if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 16
-#if STARE_VERSION_PATCH < 3
- choke me
-#endif
-#endif
-#endif
-int main() {return 0;}" GOOD_STARE_VERSION)
-cmake_print_variables(GOOD_STARE_VERSION)
-if (NOT GOOD_STARE_VERSION)
-  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
-endif ()
 
 #TARGET_LINK_LIBRARIES ( myDSO PUBLIC ${HDF5_LIBRARIES} )
 #TARGET_INCLUDE_DIRECTORIES ( myDSO PUBLIC ${HDF5_INCLUDE_DIRS} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,16 @@ set(CMAKE_REQUIRED_LIBRARIES "STARE")
 INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
+#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#error
+#endif
+#if STARE_VERSION_MINOR == 16
+#if STARE_VERSION_PATCH < 3
+#error
+#endif
+#endif
+#endif
 int main() {return 0;}" GOOD_STARE_VERSION)
 cmake_print_variables(GOOD_STARE_VERSION)
 if (NOT GOOD_STARE_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ if (NOT STARE_FOUND)
   message(fatal_error " STARE library is required.")
 endif()
 
+# STARE requires C++11
+add_compile_options( -std=c++11 )
+
 # Check STARE version, must be 0.16.3 or later.
 INCLUDE(CheckCSourceCompiles)
 CHECK_C_SOURCE_COMPILES("
@@ -116,9 +119,6 @@ CHECK_C_SOURCE_COMPILES("
 #endif
 #endif
 int main() {return 0;}" GOOD_STARE_VERSION)
-
-# STARE requires C++11
-add_compile_options( -std=c++11 )
 
 # Ensure that ncdump is available for testing.
 find_program(NCDUMP NAMES ncdump)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <STARE.h>
 #if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 0
+#if STARE_VERSION_MINOR < 15
  choke me
 #endif
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,25 +104,6 @@ endif()
 # STARE requires C++11
 add_compile_options( -std=c++11 )
 
-# Check STARE version, must be 0.16.3 or later.
-INCLUDE(CheckCSourceCompiles)
-CHECK_C_SOURCE_COMPILES("
-#include <STARE.h>
-#if STARE_VERSION_MAJOR == 0
-#if STARE_VERSION_MINOR < 16
- no good
-#endif
-#if STARE_VERSION_MINOR == 16
-#if STARE_VERSION_PATCH < 3
- no good
-#endif
-#endif
-#endif
-int main() {return 0;}" GOOD_STARE_VERSION)
-if (NOT GOOD_STARE_VERSION)
-  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
-endif ()
-
 # Ensure that ncdump is available for testing.
 find_program(NCDUMP NAMES ncdump)
 cmake_print_variables(NCDUMP)
@@ -143,6 +124,28 @@ else()
 message("OpenMP not found")
 endif()
 
+# Set the include directories.
+include_directories("${CMAKE_CURRENT_BINARY_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  "${HDF4_INCLUDE_DIR}"
+  "${HDFEOS2_INCLUDE_DIR}"
+  "${STARE_INCLUDE_DIR}")
+
+# Check STARE version, must be 0.16.3 or later.
+set(CMAKE_REQUIRED_INCLUDES "${STARE_INCLUDE_DIR}")
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+cmake_print_variables(STARE_LIBRARIES)
+set(CMAKE_REQUIRED_LINK_OPTIONS "-L${STARE_LIBRARIES}")
+set(CMAKE_REQUIRED_LIBRARIES "STARE")
+INCLUDE(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+#include <STARE.h>
+int main() {return 0;}" GOOD_STARE_VERSION)
+cmake_print_variables(GOOD_STARE_VERSION)
+if (NOT GOOD_STARE_VERSION)
+  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
+endif ()
+
 #TARGET_LINK_LIBRARIES ( myDSO PUBLIC ${HDF5_LIBRARIES} )
 #TARGET_INCLUDE_DIRECTORIES ( myDSO PUBLIC ${HDF5_INCLUDE_DIRS} )
 
@@ -155,11 +158,6 @@ ENDMACRO()
 
 # Create a config.h.
 configure_file(config.h.cmake.in config.h)
-include_directories("${CMAKE_CURRENT_BINARY_DIR}"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include"
-  "${HDF4_INCLUDE_DIR}"
-  "${HDFEOS2_INCLUDE_DIR}"
-  "${STARE_INCLUDE_DIR}")
 
 # Turn on testing.
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ site](https://github.com/SpatioTemporal/STARE) and [STARE - TOWARD
 UNPRECEDENTED GEO-DATA
 INTEROPERABILITY](https://www.researchgate.net/publication/320908197_STARE_-_TOWARD_UNPRECEDENTED_GEO-DATA_INTEROPERABILITY).
 
+For more information about STARE, see the [STARE demonstration
+presentation](https://drive.google.com/file/d/16z9pPxAnWKl2b1yKkhHyKM9pAQuGP0Z7).
+
 ## Supported Datasets
 
 Dataset        | STAREmaster ID | Full Name | Notes

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,25 @@ AC_LINK_IFELSE([
 ], [], [AC_MSG_ERROR([STARE library not present.])])
 AC_MSG_RESULT([yes])
 
+# Check the STARE version number. It must be 0.16.3 or later.
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "STARE.h"],
+[[#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#error
+#endif
+#if STARE_VERSION_MINOR == 16
+#if STARE_VERSION_PATCH < 3
+#error
+#endif
+#endif
+#endif]
+])], [good_STARE_version=yes], [good_STARE_version=no])
+AC_MSG_CHECKING([whether STARE library version is correct])
+AC_MSG_RESULT([${good_STARE_version}])
+if test "$good_STARE_version" = no; then
+   [AC_MSG_ERROR([STARE library is too old, it must be version 0.16.3 or later.])])
+fi
+
 AC_MSG_CHECKING([LIBS])
 AC_MSG_RESULT([$LIBS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "STARE.h"],
 AC_MSG_CHECKING([whether STARE library version is correct])
 AC_MSG_RESULT([${good_STARE_version}])
 if test "$good_STARE_version" = no; then
-   [AC_MSG_ERROR([STARE library is too old, it must be version 0.16.3 or later.])])
+   AC_MSG_ERROR([STARE library is too old, it must be version 0.16.3 or later.])
 fi
 
 AC_MSG_CHECKING([LIBS])


### PR DESCRIPTION
Part of #65 

Check version of STARE library in configure.ac. It must be at least 0.16.3.

Part of #62 

Added reference to the video of the STARE talk.