### PR TITLE
now check STARE library version (also referenced video of talk in README)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,14 +62,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/stare
-        key: stare-${{ runner.os }}-0.16.2
+        key: stare-${{ runner.os }}-0.16.3
 
     - name: build-stare
       if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/SpatioTemporal/STARE/archive/0.16.2-beta.tar.gz &> /dev/null
-        tar zxf 0.16.2-beta.tar.gz
-        cd STARE-0.16.2-beta/
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.3-beta.tar.gz &> /dev/null
+        tar zxf 0.16.3-beta.tar.gz
+        cd STARE-0.16.3-beta/
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=~/stare ..

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Installs
       run: |
         set -x
-        sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
+        sudo apt-get install netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev build-essential
     - name: cache-hdf4
       id: cache-hdf4
       uses: actions/cache@v2
@@ -85,7 +85,8 @@ jobs:
         cd build
         nc-config --libs
         export LIBS=`nc-config --libs`
-        cmake -DCMAKE_BUILD_TYPE=Debug --trace-source=test/CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cmake -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_BUILD_TYPE=Debug --trace-source=CMakeLists.txt  -DCMAKE_PREFIX_PATH='/home/runner/hdf4;/home/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cat CMakeFiles/CMakeOutput.log
         make VERBOSE=1
         make VERBOSE=1 test
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -45,15 +45,17 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/hdfeos2
-        key: hdfeos2-${{ runner.os }}-20v1.00
+        key: hdfeos2-${{ runner.os }}-fPIC-19v1.00
 
     - name: build-hdfeos2
       if: steps.cache-hdfeos2.outputs.cache-hit != 'true'
       run: |
-        wget https://observer.gsfc.nasa.gov/ftp/edhs/hdfeos/latest_release/HDF-EOS2.20v1.00.tar.Z  &> /dev/null
-        tar zxf HDF-EOS2.20v1.00.tar.Z
-        cd hdfeos
-        ./configure  --enable-install-include --prefix=${PWD_DIR}/hdfeos2
+        set -x
+        wget -O hdfeos2_19.zip https://git.earthdata.nasa.gov/rest/git-lfs/storage/DAS/hdfeos/ce2beacbb1ab8471a9a207def005d559f0ab725b9a4f1b1525cbee3d20aab5b0?response-content-disposition=attachment%3B%20filename%3D%22hdfeos2_19.zip%22%3B%20filename*%3Dutf-8%27%27hdfeos2_19.zip &> /dev/null
+        unzip hdfeos2_19.zip
+        cd hdfeos2_19/hdfeos2.19/hdfeos
+        chmod ug+x configure
+        CFLAGS=-fPIC ./configure  --enable-install-include --prefix=${PWD_DIR}/hdfeos2
         make
         sudo make install
         cd ..

--- a/.github/workflows/cmake_2.yml
+++ b/.github/workflows/cmake_2.yml
@@ -74,7 +74,7 @@ jobs:
         cd STARE-0.16.3-beta/
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=~/stare ..
+        cmake -DCMAKE_INSTALL_PREFIX=/Users/runner/stare ..
         make all
         sudo make install
         cd ../..
@@ -87,7 +87,7 @@ jobs:
         cd build
         nc-config --libs
         export CXX_STANDARD_LIBRARIES=-lz
-        cmake -DCMAKE_CXX_STANDARD_LIBRARIES="${CXX_STANDARD_LIBRARIES}" -DCMAKE_BUILD_TYPE=Debug --trace-source=test/CMakeLists.txt  -DCMAKE_PREFIX_PATH='/Users/runner/hdf4;/Users/runner/hdfeos2' -DSTARE_INCLUDE_DIR=~/stare/include -DSTARE_LIBRARY=~/stare/lib ..
+        cmake -DCMAKE_CXX_STANDARD_LIBRARIES="${CXX_STANDARD_LIBRARIES}" -DCMAKE_BUILD_TYPE=Debug --trace-source=test/CMakeLists.txt  -DCMAKE_PREFIX_PATH='/Users/runner/hdf4;/Users/runner/hdfeos2' -DSTARE_INCLUDE_DIR=/Users/runner/stare/include -DSTARE_LIBRARY=/Users/runner/stare/lib ..
         make VERBOSE=1
         make VERBOSE=1 test
 

--- a/.github/workflows/cmake_2.yml
+++ b/.github/workflows/cmake_2.yml
@@ -64,14 +64,14 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/stare
-        key: stare-${{ runner.os }}-0.16.2
+        key: stare-${{ runner.os }}-0.16.3
 
     - name: build-stare
       if: steps.cache-stare.outputs.cache-hit != 'true'
       run: |
-        wget https://github.com/SpatioTemporal/STARE/archive/0.16.2-beta.tar.gz &> /dev/null
-        tar zxf 0.16.2-beta.tar.gz
-        cd STARE-0.16.2-beta/
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.3-beta.tar.gz &> /dev/null
+        tar zxf 0.16.3-beta.tar.gz
+        cd STARE-0.16.3-beta/
         mkdir build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=~/stare ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,30 @@ endif()
 # STARE requires C++11
 add_compile_options( -std=c++11 )
 
+# Check STARE version, must be 0.16.3 or later.
+set(CMAKE_REQUIRED_INCLUDES "${STARE_INCLUDE_DIR}")
+set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+cmake_print_variables(STARE_LIBRARIES)
+set(CMAKE_REQUIRED_LINK_OPTIONS "-L${STARE_LIBRARIES}")
+set(CMAKE_REQUIRED_LIBRARIES "STARE")
+INCLUDE(CheckCXXSourceCompiles)
+FILE(READ "/home/runner/stare/include/STARE.h" LOGFILE)
+cmake_print_variables(LOGFILE)
+CHECK_CXX_SOURCE_COMPILES("
+#include <STARE.h>
+#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#if STARE_VERSION_PATCH < 3
+ choke me
+#endif
+#endif
+#endif
+int main() {return 0;}" GOOD_STARE_VERSION)
+cmake_print_variables(GOOD_STARE_VERSION)
+if (NOT GOOD_STARE_VERSION)
+  MESSAGE(FATAL_ERROR "STARE version 0.16.3 or later is required")  
+endif ()
+
 # Ensure that ncdump is available for testing.
 find_program(NCDUMP NAMES ncdump)
 cmake_print_variables(NCDUMP)
@@ -124,6 +148,13 @@ else()
 message("OpenMP not found")
 endif()
 
+# Set the include directories.
+include_directories("${CMAKE_CURRENT_BINARY_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  "${HDF4_INCLUDE_DIR}"
+  "${HDFEOS2_INCLUDE_DIR}"
+  "${STARE_INCLUDE_DIR}")
+
 #TARGET_LINK_LIBRARIES ( myDSO PUBLIC ${HDF5_LIBRARIES} )
 #TARGET_INCLUDE_DIRECTORIES ( myDSO PUBLIC ${HDF5_INCLUDE_DIRS} )
 
@@ -136,11 +167,6 @@ ENDMACRO()
 
 # Create a config.h.
 configure_file(config.h.cmake.in config.h)
-include_directories("${CMAKE_CURRENT_BINARY_DIR}"
-  "${CMAKE_CURRENT_SOURCE_DIR}/include"
-  "${HDF4_INCLUDE_DIR}"
-  "${HDFEOS2_INCLUDE_DIR}"
-  "${STARE_INCLUDE_DIR}")
 
 # Turn on testing.
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ site](https://github.com/SpatioTemporal/STARE) and [STARE - TOWARD
 UNPRECEDENTED GEO-DATA
 INTEROPERABILITY](https://www.researchgate.net/publication/320908197_STARE_-_TOWARD_UNPRECEDENTED_GEO-DATA_INTEROPERABILITY).
 
+For more information about STARE, see the [STARE demonstration
+presentation](https://drive.google.com/file/d/16z9pPxAnWKl2b1yKkhHyKM9pAQuGP0Z7).
+
 ## Supported Datasets
 
 Dataset        | STAREmaster ID | Full Name | Notes

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,25 @@ AC_LINK_IFELSE([
 ], [], [AC_MSG_ERROR([STARE library not present.])])
 AC_MSG_RESULT([yes])
 
+# Check the STARE version number. It must be 0.16.3 or later.
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "STARE.h"],
+[[#if STARE_VERSION_MAJOR == 0
+#if STARE_VERSION_MINOR < 16
+#error
+#endif
+#if STARE_VERSION_MINOR == 16
+#if STARE_VERSION_PATCH < 3
+#error
+#endif
+#endif
+#endif]
+])], [good_STARE_version=yes], [good_STARE_version=no])
+AC_MSG_CHECKING([whether STARE library version is correct])
+AC_MSG_RESULT([${good_STARE_version}])
+if test "$good_STARE_version" = no; then
+   AC_MSG_ERROR([STARE library is too old, it must be version 0.16.3 or later.])
+fi
+
 AC_MSG_CHECKING([LIBS])
 AC_MSG_RESULT([$LIBS])
 


### PR DESCRIPTION
Part of #65

Check version of STARE library in configure.ac. It must be at least 0.16.3.

Part of #62

Added reference to the video of the STARE talk.