### PR TITLE
Add --disable-hdf4 to build without the HDF4 and HDFEOS2 libraries

### DIFF
--- a/.github/workflows/autotools_hdfeos2.19_no_hdf4.yml
+++ b/.github/workflows/autotools_hdfeos2.19_no_hdf4.yml
@@ -1,0 +1,54 @@
+name: Autotools ubuntu-latest HDFEOS2.19 no HDF4
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    env:
+      PWD_DIR: /home/runner
+      CPPFLAGS: "-I/usr/include -I/usr/local/include -I/home/runner/stare/include"
+      LDFLAGS: "-L/home/runner/stare/lib"
+        
+    steps:
+    - uses: actions/checkout@v2
+    - name: Installs
+      run: |
+        set -x
+        sudo apt-get install -o Acquire::Retries=3 netcdf-bin libnetcdf-dev doxygen graphviz wget gfortran libjpeg-dev libz-dev
+    - name: cache-stare
+      id: cache-stare
+      uses: actions/cache@v2
+      with:
+        path: ~/stare
+        key: stare-${{ runner.os }}-0.16.3
+
+    - name: build-stare
+      if: steps.cache-stare.outputs.cache-hit != 'true'
+      run: |
+        set -x
+        wget https://github.com/SpatioTemporal/STARE/archive/0.16.3-beta.tar.gz  &> /dev/null
+        tar zxf 0.16.3-beta.tar.gz
+        cd STARE-0.16.3-beta/
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=~/stare ..
+        make all
+        sudo make install
+        cd ../..
+        
+    - name: autoreconf
+      run: autoreconf -i
+    - name: configure
+      run: |
+        export CXXFLAGS=-fpermissive
+        ./configure --disable-hdf4
+        make -j check
+
+

--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ fi
 
 # Find HDF4 and all the trimmings.
 if test "$enable_hdf4" = yes; then
-   AC_CHECK_HEADERS([hdf.h], [], [AC_MSG_ERROR([Cannot find hdf.h, set CPPFLAGS.])])
+   AC_CHECK_HEADERS([hdf.h], [], [AC_MSG_ERROR([Cannot find HDF4 header hdf.h, set CPPFLAGS or build with --disable-hdf4.])])
    AC_CHECK_HEADERS([mfhdf.h], [], [AC_MSG_ERROR([Cannot find mfhdf.h, set CPPFLAGS.])])
    AC_CHECK_LIB([z], [deflate], [], [])
    AC_CHECK_LIB([jpeg], [jpeg_set_quality], [], [])

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,15 @@ test "x$enable_large_file_tests" = xyes || enable_large_file_tests=no
 AC_MSG_RESULT([$enable_large_file_tests])
 AM_CONDITIONAL(LARGE_FILE_TESTS, [test "x$enable_large_file_tests" = xyes])
 
+# Does the user want to enable HDF4?
+AC_MSG_CHECKING([whether HDF4 and HDFEOS2 libraries should be used])
+AC_ARG_ENABLE([hdf4],
+              [AS_HELP_STRING([--disable-hdf4],
+                              [disable use of HDF4 and HDFEOS2 libraries.])])
+test "x$enable_hdf4" = xno || enable_hdf4=yes
+AC_MSG_RESULT([$enable_hdf4])
+AM_CONDITIONAL(USE_HDF4, [test "x$enable_hdf4" = xyes])
+
 # If the env. variable TEST_LARGE is set, or if
 # --with-temp-large=<directory>, use it as a place for the large
 # (i.e. > 2 GiB) files created during the large file testing.
@@ -142,8 +151,7 @@ fi
 AC_LANG_POP()
 
 # We need the math library
-#AC_CHECK_LIB([m], [floor], [],
-#[AC_MSG_ERROR([Can't find or link to the math library.])])
+AC_SEARCH_LIBS([cos], [m], [], [AC_MSG_ERROR([math library required])])
 
 # Check for netCDF C library and header. It is required.
 AC_SEARCH_LIBS([nc_create], [netcdf], [USE_NETCDF=yes],
@@ -161,25 +169,25 @@ if test "$USE_HDF5" = yes; then
 fi
 
 # Find HDF4 and all the trimmings.
-AC_CHECK_HEADERS([mfhdf.h], [], [AC_MSG_ERROR([Cannot find mfhdf.h, set CPPFLAGS.])])
-AC_CHECK_HEADERS([hdf.h], [], [AC_MSG_ERROR([Cannot find hdf.h, set CPPFLAGS.])])
-AC_CHECK_LIB([z], [deflate], [], [])
-AC_CHECK_LIB([jpeg], [jpeg_set_quality], [], [])
-AC_CHECK_LIB([df], [Hclose], [], [])
-AC_CHECK_LIB([mfhdf], [NC_arrayfill], [AC_MSG_ERROR([HDF4 library must be built with --disable-netcdf.])])
-AC_SEARCH_LIBS([SDcreate], [mfhdf], [USE_HDF4=yes], [USE_HDF4=no])
+if test "$enable_hdf4" = yes; then
+   AC_CHECK_HEADERS([hdf.h], [], [AC_MSG_ERROR([Cannot find hdf.h, set CPPFLAGS.])])
+   AC_CHECK_HEADERS([mfhdf.h], [], [AC_MSG_ERROR([Cannot find mfhdf.h, set CPPFLAGS.])])
+   AC_CHECK_LIB([z], [deflate], [], [])
+   AC_CHECK_LIB([jpeg], [jpeg_set_quality], [], [])
+   AC_CHECK_LIB([df], [Hclose], [], [])
+   AC_CHECK_LIB([mfhdf], [NC_arrayfill], [AC_MSG_ERROR([HDF4 library must be built with --disable-netcdf.])])
+   AC_SEARCH_LIBS([SDcreate], [mfhdf], [USE_HDF4=yes], [USE_HDF4=no])
+fi
 
 AC_MSG_CHECKING([whether to use HDF4])			    
 AC_MSG_RESULT([$USE_HDF4])
 if test "$USE_HDF4" = yes; then
    AC_DEFINE([USE_HDF4], [1], [If true, use HDF4.])
+   AC_SEARCH_LIBS([SWopen], [hdfeos], [], [AC_MSG_ERROR([hdfeos library required])])
+   AC_CHECK_HEADERS([HdfEosDef.h], [], [AC_MSG_ERROR([Cannot find HdfEosDef.h, set CPPFLAGS.])], [#include "mfhdf.h"])
 else
-   AC_MSG_ERROR([HDF4 is required]) # temporarily true
+   AC_MSG_WARN([HDF4 and HDFEOS2 disabled, STAREmaster will not be able to create sidecar files for MODIS data.])
 fi
-
-AC_SEARCH_LIBS([cos], [m], [], [AC_MSG_ERROR([math library required])])
-AC_SEARCH_LIBS([SWopen], [hdfeos], [], [AC_MSG_ERROR([hdfeos library required])])
-AC_CHECK_HEADERS([HdfEosDef.h], [], [AC_MSG_ERROR([Cannot find HdfEosDef.h, set CPPFLAGS.])], [#include "mfhdf.h"])
 
 # We need ncdump for testing.
 AC_CHECK_PROG(NCDUMP,[ncdump],[ncdump],[no])

--- a/include/GeoFile.h
+++ b/include/GeoFile.h
@@ -29,8 +29,6 @@ public:
     GeoFile();
     ~GeoFile();
     
-    int determineFormat(const std::string fileName, int *gf_format);
-
     /** Read file. */
     int readFile(const string fileName, int verbose, int quiet, int build_level);
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -4,4 +4,4 @@
 # Ed Hartnett 3/16/20
 
 EXTRA_DIST = SidecarFile.h GeoFile.h Modis05L2GeoFile.h ssc.h	\
-Modis09L2GeoFile.h Modis09GAGeoFile.h
+Modis09L2GeoFile.h Modis09GAGeoFile.h ModisGeoFile.h

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -5,3 +5,4 @@
 
 EXTRA_DIST = SidecarFile.h GeoFile.h Modis05L2GeoFile.h ssc.h	\
 Modis09L2GeoFile.h Modis09GAGeoFile.h ModisGeoFile.h
+

--- a/include/Modis05L2GeoFile.h
+++ b/include/Modis05L2GeoFile.h
@@ -12,7 +12,7 @@
 #include <iomanip>
 #include <vector>
 #include "ssc.h"
-#include "GeoFile.h"
+#include "ModisGeoFile.h"
 
 #ifndef MODIS_L2_GEO_FILE_H_
 #define MODIS_L2_GEO_FILE_H_
@@ -20,7 +20,7 @@
 /**
  * This class reads HDF4 data files.
  */
-class Modis05L2GeoFile : public GeoFile
+class Modis05L2GeoFile : public ModisGeoFile
 {
 public:
     Modis05L2GeoFile();

--- a/include/Modis09GAGeoFile.h
+++ b/include/Modis09GAGeoFile.h
@@ -13,7 +13,7 @@
 #include <iomanip>
 #include <vector>
 #include "ssc.h"
-#include "GeoFile.h"
+#include "ModisGeoFile.h"
 
 #ifndef MODIS09_GA_GEO_FILE_H_
 #define MODIS09_GA_GEO_FILE_H_
@@ -21,7 +21,7 @@
 /**
  * This class reads HDF4 data files.
  */
-class Modis09GAGeoFile: public GeoFile
+class Modis09GAGeoFile: public ModisGeoFile
 {
 public:
     bool fileExists(const std::string& name);

--- a/include/Modis09L2GeoFile.h
+++ b/include/Modis09L2GeoFile.h
@@ -12,7 +12,7 @@
 #include <iomanip>
 #include <vector>
 #include "ssc.h"
-#include "GeoFile.h"
+#include "ModisGeoFile.h"
 
 #ifndef MODIS09_L2_GEO_FILE_H_
 #define MODIS09_L2_GEO_FILE_H_
@@ -20,7 +20,7 @@
 /**
  * This class reads HDF4 data files.
  */
-class Modis09L2GeoFile: public GeoFile
+class Modis09L2GeoFile: public ModisGeoFile
 {
 public:
     int readFile(const std::string fileName, int verbose, int build_level);

--- a/include/ModisGeoFile.h
+++ b/include/ModisGeoFile.h
@@ -1,0 +1,30 @@
+/// @file
+
+/// This class contains the main functionality for reading a file that
+/// may be given a STARE sidecar file.
+
+/// Ed Hartnett 4/4/20
+
+#ifndef MODIS_GEO_FILE_H_ /**< Protect file from double include. */
+#define MODIS_GEO_FILE_H_
+
+#include "GeoFile.h"
+#include <mfhdf.h>
+#include <hdf.h>
+#include <HdfEosDef.h>
+
+using namespace std;
+
+/**
+ * This is the base class for a Modis data file with geolocation.
+ */
+class ModisGeoFile : public GeoFile
+{
+public:
+    ModisGeoFile();
+    ~ModisGeoFile();
+    
+    int determineFormat(const std::string fileName, int *gf_format);
+};
+
+#endif /* MODIS_GEO_FILE_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,13 +2,9 @@
 
 # Ed Hartnett 7/18/20
 
-# These are the code files.
-set(CSF_FILES SidecarFile.cpp GeoFile.cpp Modis05L2GeoFile.cpp NetcdfSidecarFile.cpp
-  Modis09L2GeoFile.cpp createSidecarFile.cpp)
-
 # This is the library we create.
 add_library(ssc SidecarFile.cpp GeoFile.cpp Modis05L2GeoFile.cpp Modis09L2GeoFile.cpp
-  Modis09GAGeoFile.cpp)
+  Modis09GAGeoFile.cpp ModisGeoFile.cpp)
 
 # This is the executable we create.
 add_executable(createSidecarFile createSidecarFile.cpp)

--- a/src/GeoFile.cpp
+++ b/src/GeoFile.cpp
@@ -1,6 +1,7 @@
 /// @file
-/// This class contains the main functionality for reading a file for
-/// which STARE sidecar files may be constructed.
+/// THis is the root class for the STAREmaster functionality. Derived
+/// classes read different format input files and create sidecar files
+/// for them.
 
 // Ed Hartnett 4/4/20
 
@@ -74,9 +75,6 @@ Options:
 #include "GeoFile.h"
 #include "SidecarFile.h"
 #include <netcdf.h>
-#include <mfhdf.h>
-#include <hdf.h>
-#include <HdfEosDef.h>
 
 /** Construct a GeoFile.
  *
@@ -149,38 +147,6 @@ GeoFile::~GeoFile()
     //    if (cover1)
     //	free(cover1);
 
-}
-
-/**
- * Determine the format of the target file.
- *
- * @param fileName Name of the target file.
- * @param gf_format Pointer to int that gets a constant indicating the
- * format. Ignored if NULL.
- *
- * @return 0 for success, error code otherwise.
- */
-int
-GeoFile::determineFormat(const std::string fileName, int *gf_format)
-{
-    int32 swathfileid;
-    
-    if (gf_format)
-	*gf_format = SSC_FORMAT_HDF4;
-
-    // Try to open as swath file with the HDF-EOS library.
-    swathfileid = SWopen((char *)fileName.c_str(), DFACC_RDONLY);
-    if (swathfileid != -1)
-    {
-	if (gf_format)
-	    *gf_format = SSC_FORMAT_MODIS_L2;	
-
-	// Close the swath file.
-	if (SWclose(swathfileid) < 0)
-	    return SSC_EHDF4ERR;
-    }
-    
-    return 0;
 }
 
 string

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,14 +7,19 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 
 # Create a library for STARE sidecar functionality.
 lib_LTLIBRARIES = libstaremaster.la
-libstaremaster_la_SOURCES = SidecarFile.cpp GeoFile.cpp		\
-Modis05L2GeoFile.cpp Modis09L2GeoFile.cpp Modis09GAGeoFile.cpp
+libstaremaster_la_SOURCES = SidecarFile.cpp GeoFile.cpp
+
+# HDF4 and HDFEOS2 is required for these.
+if USE_HDF4
+libstaremaster_la_SOURCES += Modis05L2GeoFile.cpp	\
+Modis09L2GeoFile.cpp Modis09GAGeoFile.cpp
 
 # This is the command line utility to create STARE sidecar files for
-# data files.
+# data files. 
 bin_PROGRAMS = createSidecarFile
 LDADD = libstaremaster.la
-createSidecarFile_SOURCES = createSidecarFile.cpp 
+createSidecarFile_SOURCES = createSidecarFile.cpp
+endif # USE_HDF4
 
 EXTRA_DIST = CMakeLists.txt
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,8 +11,8 @@ libstaremaster_la_SOURCES = SidecarFile.cpp GeoFile.cpp
 
 # HDF4 and HDFEOS2 is required for these.
 if USE_HDF4
-libstaremaster_la_SOURCES += Modis05L2GeoFile.cpp	\
-Modis09L2GeoFile.cpp Modis09GAGeoFile.cpp
+libstaremaster_la_SOURCES += Modis05L2GeoFile.cpp		\
+Modis09L2GeoFile.cpp Modis09GAGeoFile.cpp ModisGeoFile.cpp
 
 # This is the command line utility to create STARE sidecar files for
 # data files. 

--- a/src/ModisGeoFile.cpp
+++ b/src/ModisGeoFile.cpp
@@ -1,0 +1,66 @@
+/// @file
+/// THis is the root class for the STAREmaster functionality. Derived
+/// classes read different format input files and create sidecar files
+/// for them.
+/// 
+/// Ed Hartnett 2/21/21
+
+#include "config.h"
+#include "ModisGeoFile.h"
+#include "SidecarFile.h"
+#include <netcdf.h>
+
+/** Construct a ModisGeoFile.
+ *
+ * @return a ModisGeoFile
+ */
+ModisGeoFile::ModisGeoFile()
+{
+    cout<<"ModisGeoFile constructor\n";
+
+}
+
+/** Destroy a ModisGeoFile.
+ *
+ */
+ModisGeoFile::~ModisGeoFile()
+{
+    cout<<"ModisGeoFile destructor\n";
+
+}
+
+/**
+ * Determine the format of the target file.
+ *
+ * @param fileName Name of the target file.
+ * @param gf_format Pointer to int that gets a constant indicating the
+ * format. Ignored if NULL.
+ *
+ * @return 0 for success, error code otherwise.
+ */
+int
+ModisGeoFile::determineFormat(const std::string fileName, int *gf_format)
+{
+    int32 swathfileid;
+    
+    if (gf_format)
+	*gf_format = SSC_FORMAT_HDF4;
+
+    // Try to open as swath file with the HDF-EOS library.
+    swathfileid = SWopen((char *)fileName.c_str(), DFACC_RDONLY);
+    if (swathfileid != -1)
+    {
+	if (gf_format)
+	    *gf_format = SSC_FORMAT_MODIS_L2;	
+
+	// Close the swath file.
+	if (SWclose(swathfileid) < 0)
+	    return SSC_EHDF4ERR;
+    }
+    
+    return 0;
+}
+
+
+
+

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -8,6 +8,8 @@ LDADD = ${top_builddir}/src/libstaremaster.la
 
 SUBDIRS = data
 
+# These tests require HDF4 and the HDFEOS2 library.
+if USE_HDF4
 # This is the test program.
 check_PROGRAMS = t1 t2
 t1_SOURCES = t1.cpp
@@ -22,6 +24,7 @@ TESTS += run_tests.sh
 if LARGE_FILE_TESTS
 TESTS += run_large_file_tests.sh
 endif
+endif # USE_HDF4
 
 # These files also must be included with distribution.
 EXTRA_DIST = CMakeLists.txt run_tests.sh run_large_file_tests.sh	\


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37277297/108602798-4f09db00-7361-11eb-9cf5-aa007ee02f8d.png)

Part of #107

Add option --disable-hdf4 to autotools build, allowing build without HDF4 and HDFEOS2 libraries.

For the first time, with the readSidecar functionality, we have a reason to build without HDF4. ;-)

CMake to follow.