### PR TITLE
changed large file test, removed overly verbose output

### DIFF
--- a/src/ModisGeoFile.cpp
+++ b/src/ModisGeoFile.cpp
@@ -17,14 +17,14 @@
  * @return a ModisGeoFile
  */
 ModisGeoFile::ModisGeoFile() {
-    cout << "ModisGeoFile constructor" << endl;
+    // cout << "ModisGeoFile constructor" << endl;
 }
 
 /** Destroy a ModisGeoFile.
  *
  */
 ModisGeoFile::~ModisGeoFile() {
-    cout << "ModisGeoFile destructor\n";
+    // cout << "ModisGeoFile destructor\n";
 }
 
 /**

--- a/test/run_large_file_tests.sh.in
+++ b/test/run_large_file_tests.sh.in
@@ -1,2 +1,2 @@
 set -e
-../src/createSidecarFile -d MOD09 -r `pwd` @TEST_LARGE@/MYD09.A2020058.1515.006.2020060020205.hdf
+../src/mk_stare -d MOD09 -r `pwd` @TEST_LARGE@/MOD09.A2021181.0010.006.2021182175943.hdf


### PR DESCRIPTION
Fixes #183 

Actually MOD09 processing is working, but it's necessary to specify the type of file on the command line:
`../src/mk_stare -d MOD09 -r /home/ed/STAREmaster/test /home/ed/Downloads/MOD09.A2021181.0010.006.2021182175943.hdf`