### PR TITLE
Disable openmp by default, but allow its use on MOD09L2 processing when present and enabled

### DIFF
--- a/.github/workflows/autotools_hdfeos2.19.yml
+++ b/.github/workflows/autotools_hdfeos2.19.yml
@@ -88,7 +88,7 @@ jobs:
     - name: configure
       run: |
         export CXXFLAGS=-fpermissive
-        ./configure
+        ./configure --enable-openmp
         make -j distcheck
 
 

--- a/.github/workflows/autotools_hdfeos2.19_no_openmp.yml
+++ b/.github/workflows/autotools_hdfeos2.19_no_openmp.yml
@@ -88,7 +88,7 @@ jobs:
     - name: configure
       run: |
         export CXXFLAGS=-fpermissive
-        ./configure --disable-openmp
+        ./configure
         make -j check
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -73,9 +73,9 @@ AC_DEFINE_UNQUOTED([TEST_LARGE], ["$TEST_LARGE"], [Place to find large test file
 # disable it, even if it is present.
 AC_MSG_CHECKING([whether OpenMP is desired])
 AC_ARG_ENABLE([openmp],
-              [AS_HELP_STRING([--disable-openmp],
-                              [disable OpenMP.])])
-test "x$enable_openmp" = xno || enable_openmp=yes
+              [AS_HELP_STRING([--enable-openmp],
+                              [enable OpenMP.])])
+test "x$enable_openmp" = xyes || enable_openmp=no
 AC_MSG_RESULT([$enable_openmp])
 
 # Does the user want to build documentation?
@@ -137,11 +137,13 @@ fi
 AC_MSG_CHECKING([LIBS])
 AC_MSG_RESULT([$LIBS])
 
-# Is open_mp available? If so, use it if the user didn't disable it.
+# Did the user enable openmp? If so, confirm it is available, and set flags.
 if test "$enable_openmp" = yes; then
    AX_OPENMP([have_openmp=yes], [have_openmp=no])
    if test "x$have_openmp" = xyes; then
       CXXFLAGS="$CXXFLAGS $OPENMP_CXXFLAGS"
+   else
+      AC_MSG_ERROR([--enable-openmp used, but OpenMP is not available on this system.])
    fi
 
    AC_DEFINE([USE_OPENMP], [1], [true if OpenMP is in use])

--- a/src/Modis05L2GeoFile.cpp
+++ b/src/Modis05L2GeoFile.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <sstream>
 
-#ifdef HAVE_OPENMP
+#ifdef USE_OPENMP
 #include <omp.h>
 #endif
 

--- a/src/Modis09L2GeoFile.cpp
+++ b/src/Modis09L2GeoFile.cpp
@@ -130,7 +130,7 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
     // Calculate STARE index for each point.
     STARE index1(level, build_level);
 
-#if 0
+#ifdef USE_OPENMP
 #pragma omp parallel reduction(max : finest_resolution)
     {
         STARE index1(level, build_level);
@@ -157,9 +157,8 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
 #endif
         }
     }
-#endif
 
-#if 1
+#else
     {
 
         // geo_lat1, _lon1 and _index1 are each three arrays of MAX_ALONG by MAX_ACROSS
@@ -184,7 +183,7 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
             index1.adaptSpatialResolutionEstimatesInPlace(&(geo_index1[0][i * MAX_ACROSS]), MAX_ACROSS);
 #endif
     }
-#endif
+#endif /* USE_OPENMP */
 
     // Learn about dims for this swath.
     if ((ndims = SWinqdims(swathid, dimnames, dimids)) < 0)

--- a/src/Modis09L2GeoFile.cpp
+++ b/src/Modis09L2GeoFile.cpp
@@ -106,7 +106,7 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
         return SSC_ENOMEM;
     if (!(latitude = (float32 *) calloc(MAX_ALONG * MAX_ACROSS, sizeof(float32))))
         return SSC_ENOMEM;
-#if 1
+
     // Get lat and lon values.
     string LONGITUDE = "Longitude";
     if (SWreadfield(swathid, (char *) LONGITUDE.c_str(), NULL, NULL, NULL, longitude))
@@ -114,7 +114,7 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
     string LATITUDE = "Latitude";
     if (SWreadfield(swathid, (char *) LATITUDE.c_str(), NULL, NULL, NULL, latitude))
         return SSC_EHDF4ERR;
-#endif
+
     geo_num_i1[0] = MAX_ALONG;
     geo_num_j1[0] = MAX_ACROSS;
     if (!(geo_lat1[0] = (double *) calloc(geo_num_i1[0] * geo_num_j1[0], sizeof(double))))
@@ -177,8 +177,6 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
 #if 0
         for (unsigned long i = 0; i < MAX_ALONG; ++i)
             index1.adaptSpatialResolutionEstimatesInPlace(&(geo_index1[0][i * MAX_ACROSS]), MAX_ACROSS);
-#endif
-#if 0
         for (unsigned long i = 0; i < MAX_ALONG; ++i)
             index1.adaptSpatialResolutionEstimatesInPlace(&(geo_index1[0][i * MAX_ACROSS]), MAX_ACROSS);
 #endif
@@ -259,11 +257,10 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
             if (i && !(i % 2)) m++;
             int n = 0;
             for (int j = 0; j < MAX_ACROSS_500; j++) {
-                if (j && !(j % 2)) n++;
 		int ret;
 		double lat_delta, lon_delta;
-		// if ((ret = interp_lat(latitude, i, j, m, n, &geo_lat1[1][i * MAX_ACROSS_250 + j])))
-		//     return ret;
+
+                if (j && !(j % 2)) n++;
 		if (n == 0)
 		{
 		    lon_delta = abs(longitude[m * MAX_ACROSS + n] - longitude[m * MAX_ACROSS + n + 1]);
@@ -312,13 +309,8 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
 		    (j % 2) * lon_delta / 2;
 
                 // Calculate the stare indices.
-                //geo_index1[1][i * MAX_ACROSS_500 + j] = geo_index1[0][m * MAX_ACROSS + n];
 		geo_index1[1][i * MAX_ACROSS_500 + j] = index1.ValueFromLatLonDegrees((double)latitude[m * MAX_ACROSS + n],
                  								     (double)longitude[m * MAX_ACROSS + n], level);
-                // geo_lat1[1][i * MAX_ACROSS_500 + j] = latitude[m * MAX_ACROSS + n];
-                // geo_lon1[1][i * MAX_ACROSS_500 + j] = longitude[m * MAX_ACROSS + n];
-
-                // geo_index1[1][i * MAX_ACROSS_500 + j] = geo_index1[0][m * MAX_ACROSS + n];
             }
         }
 
@@ -421,13 +413,6 @@ Modis09L2GeoFile::readFile(const std::string fileName, int verbose, int build_le
 	    }
 	}
 	
-        // for (int i = 0; i < 10; i++) {
-        //     for (int j = 0; j < 10; j++) {
-	// 	printf("geo_lon1[2][%d]=%g\n", i * MAX_ACROSS_250 + j, geo_lon1[2][i * MAX_ACROSS_250 + j]);
-	//     }
-	// }
-
-
         d_stare_index_name.push_back("250m");
         stare_cover_name.push_back("250m");
         var_name[2].push_back("250m Surface Reflectance Band 1");


### PR DESCRIPTION
Fixes #106

Disable openmp by default, but allow its use on MOD09L2 processing when present and enabled